### PR TITLE
Add getter for MessageInput. Fixes #1

### DIFF
--- a/chatkit/src/main/java/com/stfalcon/chatkit/messages/MessageInput.java
+++ b/chatkit/src/main/java/com/stfalcon/chatkit/messages/MessageInput.java
@@ -68,6 +68,11 @@ public class MessageInput extends RelativeLayout
     public void setInputListener(InputListener inputListener) {
         this.inputListener = inputListener;
     }
+    
+    
+    public EditText getMessageInput() {
+        return messageInput;
+    }
 
 
     @Override


### PR DESCRIPTION
Users might want to edit EditText directly, so to make it possible messageInput should have getter for it.