### PR TITLE
Allow the user to get the current position of a DIALOG

### DIFF
--- a/chatkit/src/main/java/com/stfalcon/chatkit/dialogs/DialogsListAdapter.java
+++ b/chatkit/src/main/java/com/stfalcon/chatkit/dialogs/DialogsListAdapter.java
@@ -349,6 +349,13 @@ public class DialogsListAdapter<DIALOG extends IDialog>
     void setStyle(DialogListStyle dialogStyle) {
         this.dialogStyle = dialogStyle;
     }
+    
+    /**
+    * @return the position of a dialog in the dialogs list.
+    */
+    public int getDialogPosition(DIALOG dialog) {
+        return this.items.indexOf(dialog);
+    }
 
     /*
     * LISTENERS


### PR DESCRIPTION
This should close issue #29. I believe that providing the user with the whole list of DIALOG objects is a bit "dangerous", users can modify that collection and feed it back to the adapter and given the current implementation that's not something we might want. So having a ```getDialogPosition()``` method should solve the case when the user needs to have the current adapter position of a certain dialog.