### PR TITLE
IDs aren't always Strings

### DIFF
--- a/chatkit/src/main/java/com/stfalcon/chatkit/commons/models/IMessage.java
+++ b/chatkit/src/main/java/com/stfalcon/chatkit/commons/models/IMessage.java
@@ -21,14 +21,14 @@ import java.util.Date;
 /**
  * For implementing by real message model
  */
-public interface IMessage {
+public interface IMessage<T> {
 
     /**
      * Returns message identifier
      *
      * @return the message id
      */
-    String getId();
+    T getId();
 
     /**
      * Returns message text

--- a/chatkit/src/main/java/com/stfalcon/chatkit/commons/models/IUser.java
+++ b/chatkit/src/main/java/com/stfalcon/chatkit/commons/models/IUser.java
@@ -19,14 +19,14 @@ package com.stfalcon.chatkit.commons.models;
 /**
  * For implementing by real user model
  */
-public interface IUser {
+public interface IUser<T> {
 
     /**
      * Returns the user's id
      *
      * @return the user's id
      * */
-    String getId();
+    T getId();
 
     /**
      * Returns the user's name

--- a/chatkit/src/main/java/com/stfalcon/chatkit/commons/models/MessageContentType.java
+++ b/chatkit/src/main/java/com/stfalcon/chatkit/commons/models/MessageContentType.java
@@ -27,12 +27,12 @@ import com.stfalcon.chatkit.messages.MessageHolders;
  * Interface used to mark messages as custom content types. For its representation see {@link MessageHolders}
  */
 
-public interface MessageContentType extends IMessage {
+public interface MessageContentType<T> extends IMessage<T> {
 
     /**
      * Default media type for image message.
      */
-    interface Image extends IMessage {
+    interface Image<T> extends IMessage<T> {
         @Nullable
         String getImageUrl();
     }

--- a/chatkit/src/main/java/com/stfalcon/chatkit/messages/MessageHolders.java
+++ b/chatkit/src/main/java/com/stfalcon/chatkit/messages/MessageHolders.java
@@ -387,7 +387,7 @@ public class MessageHolders {
 
         if (item instanceof IMessage) {
             IMessage message = (IMessage) item;
-            isOutcoming = message.getUser().getId().contentEquals(senderId);
+            isOutcoming = message.getUser().getId().equals(senderId);
             viewType = getContentViewType(message);
 
         } else viewType = VIEW_TYPE_DATE_HEADER;

--- a/chatkit/src/main/java/com/stfalcon/chatkit/messages/MessagesListAdapter.java
+++ b/chatkit/src/main/java/com/stfalcon/chatkit/messages/MessagesListAdapter.java
@@ -201,7 +201,7 @@ public class MessagesListAdapter<MESSAGE extends IMessage>
      * @param oldId      an identifier of message to update.
      * @param newMessage new message object.
      */
-    public boolean update(String oldId, MESSAGE newMessage) {
+    public boolean update(Object oldId, MESSAGE newMessage) {
         int position = getMessagePositionById(oldId);
         if (position >= 0) {
             Wrapper<MESSAGE> element = new Wrapper<>(newMessage);
@@ -252,7 +252,7 @@ public class MessagesListAdapter<MESSAGE extends IMessage>
      *
      * @param id identifier of message to delete.
      */
-    public void deleteById(String id) {
+    public void deleteById(Object id) {
         int index = getMessagePositionById(id);
         if (index >= 0) {
             items.remove(index);
@@ -498,12 +498,12 @@ public class MessagesListAdapter<MESSAGE extends IMessage>
     }
 
     @SuppressWarnings("unchecked")
-    private int getMessagePositionById(String id) {
+    private int getMessagePositionById(Object id) {
         for (int i = 0; i < items.size(); i++) {
             Wrapper wrapper = items.get(i);
             if (wrapper.item instanceof IMessage) {
                 MESSAGE message = (MESSAGE) wrapper.item;
-                if (message.getId().contentEquals(id)) {
+                if (message.getId().equals(id)) {
                     return i;
                 }
             }
@@ -525,7 +525,7 @@ public class MessagesListAdapter<MESSAGE extends IMessage>
         int prevPosition = position + 1;
         if (items.size() <= prevPosition) return false;
         else return items.get(prevPosition).item instanceof IMessage
-                && ((MESSAGE) items.get(prevPosition).item).getUser().getId().contentEquals(id);
+                && ((MESSAGE) items.get(prevPosition).item).getUser().getId().equals(id);
     }
 
     private void incrementSelectedItemsCount() {

--- a/docs/COMPONENT_MESSAGES_LIST.md
+++ b/docs/COMPONENT_MESSAGES_LIST.md
@@ -31,10 +31,10 @@ Anyway, you can pass second parameter as `null`, and avatars will be hidden.
 
 #### Prepare your model
 
-To be able to add messages, you must implement the `IMessage` interface into your existing model and override its methods:
+To be able to add messages, you must implement the `IMessage<ID>` interface into your existing model and override its methods:
 
 ```java
-public class Message implements IMessage {
+public class Message implements IMessage<String> {
 
    /*...*/
 
@@ -59,10 +59,10 @@ public class Message implements IMessage {
    }
 }
 ```
-As you can see, you need also to add the Author object, which must to implement `IUser` interface:
+As you can see, you need also to add the Author object, which must to implement `IUser<ID>` interface:
 
 ```java
-public class Author implements IUser {
+public class Author implements IUser<String> {
 
    /*...*/
 
@@ -115,8 +115,8 @@ The `page` variable contains next page number to load (which is equals to the am
 Can modern chat exist without media message exchange? The right answer is - no, it can't. Even in the simplest apps this feature is “must have”. With ChatKit, adding this feature is easier than ever!
 At this moment "out of the box" library contains anly the most popular type of media messages - image messages. All you need to implement it is to mark your `Message` object with the `MessageContentType.Image` interface and override its `getImageUrl()` method:
 ```java
-public class Message implements IMessage,
-       MessageContentType.Image {
+public class Message implements IMessage<String>,
+       MessageContentType.Image<String> {
     ...
     @Override
     public String getImageUrl() {

--- a/sample/src/main/java/com/stfalcon/chatkit/sample/common/data/model/Message.java
+++ b/sample/src/main/java/com/stfalcon/chatkit/sample/common/data/model/Message.java
@@ -8,9 +8,9 @@ import java.util.Date;
 /*
  * Created by troy379 on 04.04.17.
  */
-public class Message implements IMessage,
-        MessageContentType.Image, /*this is for default image messages implementation*/
-        MessageContentType /*and this one is for custom content type (in this case - voice message)*/ {
+public class Message implements IMessage<String>,
+        MessageContentType.Image<String>, /*this is for default image messages implementation*/
+        MessageContentType<String> /*and this one is for custom content type (in this case - voice message)*/ {
 
     private String id;
     private String text;

--- a/sample/src/main/java/com/stfalcon/chatkit/sample/common/data/model/User.java
+++ b/sample/src/main/java/com/stfalcon/chatkit/sample/common/data/model/User.java
@@ -5,7 +5,7 @@ import com.stfalcon.chatkit.commons.models.IUser;
 /*
  * Created by troy379 on 04.04.17.
  */
-public class User implements IUser {
+public class User implements IUser<String> {
 
     private String id;
     private String name;


### PR DESCRIPTION
I think this is pretty self explanatory.

IDs don't always have to be strings, so making this change prevents the developers needing to `toString` their IDs of their models every time you need to get the ID.