### PR TITLE
Made correction to DialogList documentation

### DIFF
--- a/docs/COMPONENT_DIALOGS_LIST.MD
+++ b/docs/COMPONENT_DIALOGS_LIST.MD
@@ -36,7 +36,7 @@ dialogsListView.setAdapter(dialogsListAdapter);
 
 #### Prepare your model
 
-To be able to add dialog, you must implement the `IDealog` interface to your existing model and override its methods:
+To be able to add dialog, you must implement the `IDialog` interface to your existing model and override its methods:
 
 ```java
 public class DefaultDialog implements IDialog {


### PR DESCRIPTION
A typographic error was made in the documentation for the DialogList component under the 'Prepare your model' section.
`IDialog` was written as `IDealog`. This pull request corrects that error.