### PR TITLE
Add nullable for getImageUrl()

### DIFF
--- a/chatkit/src/main/java/com/stfalcon/chatkit/commons/models/MessageContentType.java
+++ b/chatkit/src/main/java/com/stfalcon/chatkit/commons/models/MessageContentType.java
@@ -16,6 +16,7 @@
 
 package com.stfalcon.chatkit.commons.models;
 
+import android.support.annotation.Nullable;
 import com.stfalcon.chatkit.messages.MessageHolders;
 
 /*
@@ -32,6 +33,7 @@ public interface MessageContentType extends IMessage {
      * Default media type for image message.
      */
     interface Image extends IMessage {
+        @Nullable
         String getImageUrl();
     }
 


### PR DESCRIPTION
In a Kotlin project getImageUrl() thinks it will always return a URL, which makes it had to distinguish between a message and image. 

Added a simple @nullable annotation to make it compatible with Kotlin