### PR TITLE
Image inherit from the basic Content type

### DIFF
--- a/chatkit/src/main/java/com/stfalcon/chatkit/commons/models/MessageContentType.java
+++ b/chatkit/src/main/java/com/stfalcon/chatkit/commons/models/MessageContentType.java
@@ -31,7 +31,7 @@ public interface MessageContentType extends IMessage {
     /**
      * Default media type for image message.
      */
-    interface Image extends IMessage {
+    interface Image implements MessageContentType {
         String getImageUrl();
     }
 


### PR DESCRIPTION
Don't you think MessageContentType.Image should inherit from MessageContentType? why don't do it, if MessageContentType is the basic type?