### PR TITLE
Removal of forced software layer rendering

### DIFF
--- a/chatkit/src/main/java/com/stfalcon/chatkit/messages/MessagesList.java
+++ b/chatkit/src/main/java/com/stfalcon/chatkit/messages/MessagesList.java
@@ -23,7 +23,6 @@ import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.SimpleItemAnimator;
 import android.util.AttributeSet;
-import android.view.View;
 
 import com.stfalcon.chatkit.commons.models.IMessage;
 
@@ -35,19 +34,16 @@ public class MessagesList extends RecyclerView {
 
     public MessagesList(Context context) {
         super(context);
-        setLayerType(View.LAYER_TYPE_SOFTWARE, null);
     }
 
     public MessagesList(Context context, @Nullable AttributeSet attrs) {
         super(context, attrs);
         parseStyle(context, attrs);
-        setLayerType(View.LAYER_TYPE_SOFTWARE, null);
     }
 
     public MessagesList(Context context, @Nullable AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);
         parseStyle(context, attrs);
-        setLayerType(View.LAYER_TYPE_SOFTWARE, null);
     }
 
     /**


### PR DESCRIPTION
Commit 95fc88e attempted to rectify artefacts being drawn using a forced software layer rendering. This process has had significant consequences on performance (#174) and introduced breaking rendering changes, for instance card views are no longer rendered correctly (see screenshots below). Furthermore, the developer documentation states that ["Software layers should be avoided when the affected view tree updates often."](https://developer.android.com/reference/android/view/View.html#LAYER_TYPE_SOFTWARE) which in the case of a chat interface can be very frequent.

A suggestion to prevent the artefacts from being rendered, that may need to be put in the usage docs/faq, you can instead apply the [descendantFocusability="beforeDescendants"](https://developer.android.com/reference/android/view/ViewGroup.html#attr_android:descendantFocusability) on the layout container to ensure it has focus rather than a descendant message bubble.

**With software layer rendering**
![screenshot_1533256066](https://user-images.githubusercontent.com/1082672/43617962-f0a8869c-9708-11e8-8359-b1e498483879.png)

**Without software layer rendering**
![screenshot_1533256094](https://user-images.githubusercontent.com/1082672/43617958-de9573ac-9708-11e8-93d9-17f82f30eab5.png)