### PR TITLE
Add ability to set custom padding to message input field

### DIFF
--- a/chatkit/src/main/java/com/stfalcon/chatkit/messages/MessageInput.java
+++ b/chatkit/src/main/java/com/stfalcon/chatkit/messages/MessageInput.java
@@ -191,6 +191,12 @@ public class MessageInput extends RelativeLayout
         this.messageInput.setTextSize(TypedValue.COMPLEX_UNIT_PX, style.getInputTextSize());
         this.messageInput.setTextColor(style.getInputTextColor());
         this.messageInput.setHintTextColor(style.getInputHintColor());
+        this.messageInput.setPadding(
+                style.getInputFieldPaddingLeft(),
+                style.getInputFieldPaddingTop(),
+                style.getInputFieldPaddingRight(),
+                style.getInputFieldPaddingBottom()
+        );
         ViewCompat.setBackground(this.messageInput, style.getInputBackground());
         setCursor(style.getInputCursorDrawable());
 

--- a/chatkit/src/main/java/com/stfalcon/chatkit/messages/MessageInputStyle.java
+++ b/chatkit/src/main/java/com/stfalcon/chatkit/messages/MessageInputStyle.java
@@ -78,6 +78,11 @@ class MessageInputStyle extends Style {
     private Drawable inputBackground;
     private Drawable inputCursorDrawable;
 
+    private int inputFieldPaddingLeft;
+    private int inputFieldPaddingRight;
+    private int inputFieldPaddingTop;
+    private int inputFieldPaddingBottom;
+
     private int inputDefaultPaddingLeft;
     private int inputDefaultPaddingRight;
     private int inputDefaultPaddingTop;
@@ -141,6 +146,15 @@ class MessageInputStyle extends Style {
 
         style.inputBackground = typedArray.getDrawable(R.styleable.MessageInput_inputBackground);
         style.inputCursorDrawable = typedArray.getDrawable(R.styleable.MessageInput_inputCursorDrawable);
+
+        style.inputFieldPaddingLeft = typedArray.getDimensionPixelSize(R.styleable.MessageInput_inputPaddingLeft,
+                style.getDimension(R.dimen.input_field_padding_left));
+        style.inputFieldPaddingRight = typedArray.getDimensionPixelSize(R.styleable.MessageInput_inputPaddingRight,
+                style.getDimension(R.dimen.input_field_padding_right));
+        style.inputFieldPaddingTop = typedArray.getDimensionPixelSize(R.styleable.MessageInput_inputPaddingTop,
+                style.getDimension(R.dimen.input_field_padding_top));
+        style.inputFieldPaddingBottom = typedArray.getDimensionPixelSize(R.styleable.MessageInput_inputPaddingBottom,
+                style.getDimension(R.dimen.input_field_padding_bottom));
 
         style.delayTypingStatus = typedArray.getInt(R.styleable.MessageInput_delayTypingStatus, DEFAULT_DELAY_TYPING_STATUS);
 
@@ -269,6 +283,22 @@ class MessageInputStyle extends Style {
 
     protected Drawable getInputCursorDrawable() {
         return inputCursorDrawable;
+    }
+
+    protected int getInputFieldPaddingLeft() {
+        return inputFieldPaddingLeft;
+    }
+
+    protected int getInputFieldPaddingRight() {
+        return inputFieldPaddingRight;
+    }
+
+    protected int getInputFieldPaddingTop() {
+        return inputFieldPaddingTop;
+    }
+
+    protected int getInputFieldPaddingBottom() {
+        return inputFieldPaddingBottom;
     }
 
     protected int getInputDefaultPaddingLeft() {

--- a/chatkit/src/main/res/values/attrs.xml
+++ b/chatkit/src/main/res/values/attrs.xml
@@ -43,6 +43,11 @@
         <attr name="inputBackground" format="reference"/>
         <attr name="inputCursorDrawable" format="reference"/>
 
+        <attr name="inputPaddingLeft" format="dimension|reference"/>
+        <attr name="inputPaddingRight" format="dimension|reference"/>
+        <attr name="inputPaddingTop" format="dimension|reference"/>
+        <attr name="inputPaddingBottom" format="dimension|reference"/>
+
         <attr name="delayTypingStatus" format="integer"/>
     </declare-styleable>
 

--- a/chatkit/src/main/res/values/dimens.xml
+++ b/chatkit/src/main/res/values/dimens.xml
@@ -7,6 +7,10 @@
     <dimen name="input_padding_right">16sp</dimen>
     <dimen name="input_padding_top">8sp</dimen>
     <dimen name="input_padding_bottom">8sp</dimen>
+    <dimen name="input_field_padding_left">0dp</dimen>
+    <dimen name="input_field_padding_right">0dp</dimen>
+    <dimen name="input_field_padding_top">8dp</dimen>
+    <dimen name="input_field_padding_bottom">8dp</dimen>
 
     <dimen name="message_bubble_corners_radius">15dp</dimen>
 

--- a/docs/STYLES_ATTR.md
+++ b/docs/STYLES_ATTR.md
@@ -127,4 +127,8 @@
 | `inputHintColor` | Sets text color of hint in message input field|
 | `inputBackground` | Sets background for input message view |
 | `inputCursorDrawable` | Sets cursor drawable for input message EditText |
+| `inputPaddingLeft` | Sets left padding for message input field |
+| `inputPaddingRight` | Sets right padding for message input field |
+| `inputPaddingTop` | Sets top padding for message input field |
+| `inputPaddingBottom` | Sets bottom padding for message input field |
 | `delayTypingStatus` | Sets delay typing for TypingListener|


### PR DESCRIPTION
### Description:
This PR adds ability to specify custom paddings for message input EditText.

### Why is it necessary?
In the current version of library you can not set padding values to message input field. And default values for side paddings are 0dp, which looks bad in case you have custom input background. Examples below:
![IMG_20190628_132821](https://user-images.githubusercontent.com/14264289/60338123-bd8c6f00-99ad-11e9-8481-8fe3af8e87a3.jpg)
![IMG_20190628_132853](https://user-images.githubusercontent.com/14264289/60338124-bd8c6f00-99ad-11e9-96bf-b88fe0c06d29.jpg)

### How it is implemented:
New attributes (inputPaddingLeft, inputPaddingRight, inputPaddingTop, inputPaddingBottom) were added to MessageInput view.

