### PR TITLE
Pass the dialog and user to the image loader

### DIFF
--- a/chatkit/src/main/java/com/stfalcon/chatkit/dialogs/DialogsListAdapter.java
+++ b/chatkit/src/main/java/com/stfalcon/chatkit/dialogs/DialogsListAdapter.java
@@ -33,6 +33,7 @@ import com.stfalcon.chatkit.commons.ImageLoader;
 import com.stfalcon.chatkit.commons.ViewHolder;
 import com.stfalcon.chatkit.commons.models.IDialog;
 import com.stfalcon.chatkit.commons.models.IMessage;
+import com.stfalcon.chatkit.commons.models.IUser;
 import com.stfalcon.chatkit.utils.DateFormatter;
 
 import java.lang.reflect.Constructor;
@@ -657,12 +658,13 @@ public class DialogsListAdapter<DIALOG extends IDialog>
 
             //Set Dialog avatar
             if (imageLoader != null) {
-                imageLoader.loadImage(ivAvatar, dialog.getDialogPhoto(), null);
+                imageLoader.loadImage(ivAvatar, dialog.getDialogPhoto(), dialog);
             }
 
             //Set Last message user avatar with check if there is last message
             if (imageLoader != null && dialog.getLastMessage() != null) {
-                imageLoader.loadImage(ivLastMessageUser, dialog.getLastMessage().getUser().getAvatar(), null);
+                IUser user = dialog.getLastMessage().getUser();
+                imageLoader.loadImage(ivLastMessageUser, user.getAvatar(), user);
             }
             ivLastMessageUser.setVisibility(dialogStyle.isDialogMessageAvatarEnabled()
                     && dialog.getUsers().size() > 1


### PR DESCRIPTION
I don't know if there is another way to achieve this, but I want to generate a composite image for the chat based on the users who are in that chat. Passing the dialog gives me access to the chat object which would allow me to do this. Since the payload is null normally, I don't see much downside to this change and there is an upside in that it offers more flexibility. 